### PR TITLE
add `update_input` to `workchain_and_builder`

### DIFF
--- a/aiidalab_qe_vibroscopy/app/workchain.py
+++ b/aiidalab_qe_vibroscopy/app/workchain.py
@@ -77,9 +77,13 @@ def get_builder(codes, structure, parameters):
 
     return builder
 
+def update_inputs(inputs, ctx):
+    """Update the inputs using context."""
+    inputs.structure = ctx.current_structure
 
 workchain_and_builder = {
     "workchain": VibroWorkChain,
     "exclude": ("clean_workdir",),
     "get_builder": get_builder,
+    "update_inputs": update_inputs,
 }


### PR DESCRIPTION
In the new QEApp version (PR: https://github.com/aiidalab/aiidalab-qe/pull/656), the plugin needs to define an `update_input` method. In this case, when the user chooses to run a geometry optimization, the plugin will use the optimized structure from the context.