### PR TITLE
find `phonopy` path automatically

### DIFF
--- a/phonopy_install.py
+++ b/phonopy_install.py
@@ -2,6 +2,7 @@ from aiida.common.exceptions import NotExistent
 import subprocess
 from aiida.orm import load_code
 from aiida import load_profile
+import shutil
 
 
 def install_phonopy():
@@ -9,6 +10,8 @@ def install_phonopy():
     try:
         load_code("phonopy@localhost")
     except NotExistent:
+        # Use shutil.which to find the path of the phonopy executable
+        phonopy_path = shutil.which("phonopy")
         # Construct the command as a list of arguments
         command = [
             "verdi",
@@ -23,7 +26,7 @@ def install_phonopy():
             "--computer",
             "localhost",
             "--filepath-executable",
-            "/opt/conda/bin/phonopy",
+            phonopy_path,
         ]
 
         # Use subprocess.run to run the command


### PR DESCRIPTION
In my test using latest QEApp, I installed the plugin in the plugin management page, and the path of `phonopy` is 
```console
$ which phonopy
/home/jovyan/.local/bin/phonopy
```
which is different from `"/opt/conda/bin/phonopy". Thus it is better if we read the path automatically.